### PR TITLE
WIP: Make new APITokens feature compatible with Atmosphere API

### DIFF
--- a/troposphere/static/js/actions/APITokenActions.js
+++ b/troposphere/static/js/actions/APITokenActions.js
@@ -3,7 +3,7 @@ import APIToken from "models/APIToken";
 import Utils from "./Utils";
 
 export default {
-    create: ({name, atmo_user}) => {
+    create: ({name, atmo_user}, callback) => {
         if (!name) throw new Error("Missing Token name");
         if (!atmo_user) throw new Error("Missing Token author");
         let apiToken = new APIToken({
@@ -18,6 +18,7 @@ export default {
             .save()
             .done(() => {
                 Utils.dispatch(APITokenConstants.UPDATE_TOKEN, {apiToken});
+                callback(apiToken);
             })
             .fail(() => {
                 Utils.dispatch(APITokenConstants.REMOVE_TOKEN, {apiToken});

--- a/troposphere/static/js/bootstrapper.js
+++ b/troposphere/static/js/bootstrapper.js
@@ -91,6 +91,7 @@ stores.AllocationSourceStore = require("stores/AllocationSourceStore");
 import actions from "actions";
 
 actions.AccountActions = require("actions/AccountActions");
+actions.APITokenActions = require("actions/APITokenActions");
 actions.BadgeActions = require("actions/BadgeActions");
 actions.GroupActions = require("actions/GroupActions");
 actions.ExternalLinkActions = require("actions/ExternalLinkActions");

--- a/troposphere/static/js/collections/APITokenCollection.js
+++ b/troposphere/static/js/collections/APITokenCollection.js
@@ -4,8 +4,8 @@ import globals from "globals";
 
 export default Backbone.Collection.extend({
     model: APIToken,
-    url: globals.API_V2_ROOT + "/ssh_keys",
+    url: globals.API_V2_ROOT + "/access_tokens",
     parse: function(data) {
-        return [{name: "Home CLI", id: 2}];
+        return data.results;
     }
 });

--- a/troposphere/static/js/components/modals/api_token/APITokenCreate.jsx
+++ b/troposphere/static/js/components/modals/api_token/APITokenCreate.jsx
@@ -37,11 +37,12 @@ export default React.createClass({
         this.setState({
             isSubmitting: true
         });
+        var response = actions.APITokenActions.create(attributes);
         setTimeout(() => {
             this.setState({
                 isSubmitting: false,
                 successView: true,
-                hash: "343rw24fg983498j3urfu39"
+                hash: response.changed.token
             });
         }, 2000);
     },

--- a/troposphere/static/js/components/modals/api_token/APITokenCreate.jsx
+++ b/troposphere/static/js/components/modals/api_token/APITokenCreate.jsx
@@ -37,14 +37,13 @@ export default React.createClass({
         this.setState({
             isSubmitting: true
         });
-        var response = actions.APITokenActions.create(attributes);
-        setTimeout(() => {
+        actions.APITokenActions.create(attributes, (response) => {
             this.setState({
                 isSubmitting: false,
                 successView: true,
                 hash: response.changed.token
             });
-        }, 2000);
+        });
     },
 
     renderFormView() {

--- a/troposphere/static/js/components/modals/api_token/APITokenDelete.jsx
+++ b/troposphere/static/js/components/modals/api_token/APITokenDelete.jsx
@@ -5,16 +5,29 @@ import actions from "actions";
 import {RaisedButton} from "material-ui";
 import WarningIcon from "material-ui/svg-icons/alert/warning";
 
-export default React.createClass({
+import subscribe from "utilities/subscribe";
+
+const APITokenDelete = React.createClass({
     propTypes: {
         token: React.PropTypes.instanceOf(Backbone.Model),
-        user: React.PropTypes.number.isRequired
     },
 
     mixins: [BootstrapModalMixin],
 
     onSubmit() {
         this.hide();
+        let token = this.props.token;
+        let {APITokenStore} = this.props.subscriptions;
+        APITokenStore.remove(token);
+        token.destroy({
+            success: function() {
+                APITokenStore.emitChange();
+            },
+            error: function() {
+                APITokenStore.add(token);
+                APITokenStore.emitChange();
+            }
+        });
     },
 
     render() {
@@ -58,3 +71,5 @@ export default React.createClass({
         );
     }
 });
+
+export default subscribe(APITokenDelete, ["APITokenStore"]);

--- a/troposphere/static/js/components/modals/api_token/APITokenEdit.jsx
+++ b/troposphere/static/js/components/modals/api_token/APITokenEdit.jsx
@@ -7,7 +7,7 @@ import {RaisedButton} from "material-ui";
 export default React.createClass({
     mixins: [BootstrapModalMixin],
     propTypes: {
-        token: React.PropTypes.number.isRequired
+        token: React.PropTypes.object.isRequired
     },
 
     getInitialState() {
@@ -25,7 +25,9 @@ export default React.createClass({
     },
 
     onSubmit() {
+        let token = this.props.token;
         const {name} = this.state;
+        actions.APITokenActions.update(token, { name: name.trim() });
         this.hide();
     },
 

--- a/troposphere/static/js/components/settings/advanced/TokenListView.jsx
+++ b/troposphere/static/js/components/settings/advanced/TokenListView.jsx
@@ -88,7 +88,6 @@ const APITokenConfiguration = React.createClass({
         let {APITokenStore} = this.props.subscriptions,
             profile = this.state.profile,
             api_token = APITokenStore.getAll();
-        debugger;
         return (
             <div>
                 <h3>Personal Access Tokens</h3>

--- a/troposphere/static/js/models/APIToken.js
+++ b/troposphere/static/js/models/APIToken.js
@@ -2,5 +2,5 @@ import Backbone from "backbone";
 import globals from "globals";
 
 export default Backbone.Model.extend({
-    urlRoot: globals.API_V2_ROOT + "/ssh_keys"
+    urlRoot: globals.API_V2_ROOT + "/access_tokens"
 });

--- a/troposphere/static/js/stores/APITokenStore.js
+++ b/troposphere/static/js/stores/APITokenStore.js
@@ -15,15 +15,15 @@ Dispatcher.register(function(dispatch) {
 
     switch (actionType) {
         case APITokenConstants.ADD_TOKEN:
-            store.add(payload.sshKey);
+            store.add(payload.apiToken);
             break;
 
         case APITokenConstants.REMOVE_TOKEN:
-            store.remove(payload.sshKey);
+            store.remove(payload.apiToken);
             break;
 
         case APITokenConstants.UPDATE_TOKEN:
-            store.update(payload.sshKey);
+            store.update(payload.apiToken);
             break;
 
         default:

--- a/troposphere/static/js/stores/APITokenStore.js
+++ b/troposphere/static/js/stores/APITokenStore.js
@@ -8,6 +8,7 @@ var APITokenStore = BaseStore.extend({
 });
 
 let store = new APITokenStore();
+
 Dispatcher.register(function(dispatch) {
     var actionType = dispatch.action.actionType;
     var payload = dispatch.action.payload;


### PR DESCRIPTION
TODO:
- [x] Enable loading API tokens from Atmosphere API
- [x] Enable creating new API tokens
- [x] Enable editing API tokens
- [x] Enable deleting API tokens

Currently, it is all in working order. ~~The only problem is that when creating a token, I still use the timeout to wait before showing the resulting token. I am working on getting it to work with a promise.~~

~~Also, after creating a token, it cannot be deleted until refreshing the page. However, tokens that already existed could be deleted without a refresh.~~ Small change to the Atmosphere API fixed this

https://github.com/calvinmclean/atmosphere/tree/api-tokens